### PR TITLE
Fix #19

### DIFF
--- a/DiscordRPC.py
+++ b/DiscordRPC.py
@@ -18,49 +18,30 @@ def enable_RPC():
         already_disabled = False
 
 
-def update_Status(track, title, artist, album, time_remaining, username, artwork, buttonIsEnabled):
+def update_Status(track, title, artist, time_remaining, username, artwork, buttonIsEnabled):
     global start_time, LastTrack
     if len(title) < 2:
         title = title+"  "
     if LastTrack == track:
-        pass
+        return
+
+    print("Now Playing: " + track)
+    start_time = datetime.datetime.now().timestamp()
+    LastTrack = track
+
+    time_remaining = str(time_remaining)[0:3]
+    if time_remaining == '0':
+        time_remaining = None
     else:
-        print("Now Playing: " + track)
-        start_time = datetime.datetime.now().timestamp()
-        LastTrack = track
-        trackArtistAlbum = artist + " - " + album
-        time_remaining = str(time_remaining)[0:3]
+        time_remaining = float(time_remaining) + start_time
+
+    lastfmProfileButton = None
+    if buttonIsEnabled:
         lastfmProfileButton = [{"label": "View Last.fm Profile", "url": str("https://www.last.fm/user/" + username)}]
-        if time_remaining != '0':
-            if album != 'None':
-                if buttonIsEnabled:
-                    RPC.update(details=title, state=album, end=float(time_remaining)+start_time,
-                        large_image=artwork, large_text=album, buttons=lastfmProfileButton)
-                else:
-                    RPC.update(details=title, state=album, end=float(time_remaining)+start_time,
-                        large_image=artwork, large_text=album)
-            else:
-                if buttonIsEnabled:
-                    RPC.update(details=title, state=trackArtistAlbum, end=float(time_remaining)+start_time,
-                        large_image=artwork, large_text=album, buttons=lastfmProfileButton)
-                else:
-                    RPC.update(details=title, state=trackArtistAlbum, end=float(time_remaining)+start_time,
-                        large_image=artwork, large_text=album)
-        else:
-            if album != 'None':
-                if buttonIsEnabled:
-                    RPC.update(details=title, state=album,
-                        large_image=artwork, large_text=album, buttons=lastfmProfileButton)
-                else:
-                    RPC.update(details=title, state=album,
-                        large_image=artwork, large_text=album)
-            else:
-                if buttonIsEnabled:
-                    RPC.update(details=title, state=album,
-                        large_image=artwork, large_text=album, buttons=lastfmProfileButton)
-                else:
-                    RPC.update(details=title, state=album,
-                        large_image=artwork, large_text=album)
+
+    RPC.update(details=title, state=track, end=time_remaining,
+               large_image=artwork, large_text=track, buttons=lastfmProfileButton)
+
 
 def disable_RPC():
     global already_enabled

--- a/Last_fm_api.py
+++ b/Last_fm_api.py
@@ -33,11 +33,12 @@ class LastFmUser:
         if current_track is not None:
             track = current_track
             try:
-                album,time_remaining = None, 0
-                album = track.get_album()
+                time_remaining = 0
                 title = track.get_title()
                 artist = track.get_artist()
-                artwork = album.get_cover_image()
+                artwork = track.get_cover_image()
+                if artwork is None:
+                    artwork = 'https://raw.githubusercontent.com/Gust4Oliveira/Last.fm-Discord-Rich-Presence/master/assets/last.fm.png'
                 time_remaining = track.get_duration()
             except pylast.WSError:
                 pass
@@ -46,7 +47,7 @@ class LastFmUser:
                     "The app couldn't comunicate with last.fm servers, check your internet connection!")
                 pass
             RPC.enable_RPC()
-            RPC.update_Status(str(track), str(title), str(artist), str(album), time_remaining, self.username, artwork, button_state)
+            RPC.update_Status(str(track), title, str(artist), time_remaining, self.username, artwork, button_state)
             time.sleep(self.cooldown+8)
         else:
             print("No song detected, checking again in " +


### PR DESCRIPTION
This pull request fixes #19.
The cause of the bug is: some tracks do not have an album. So, when `track.get_album()` is called, it returns `None` sometimes. Then `get_artwork()` would be called on `None`, resulting in the error.
Fixed by not using `Album`. `Album` and `Track` inherit `_Opus`, so they have similar functionality. `get_artwork` is now called on `Track`.
If there is no artwork, it displays the last.fm logo from `assets/last.fm.png`.

The `update_Status` function was modified to remove the unneeded `Album` parts, and simplified.